### PR TITLE
feat(excalidraw): force excalidraw to export transparent background

### DIFF
--- a/src/conversion/compiler/excalidraw.ts
+++ b/src/conversion/compiler/excalidraw.ts
@@ -11,7 +11,7 @@ export async function convertToHTMLSVG(file: TFile, app: App) {
 		if (!excalidraw) return null;
 		// @ts-ignore
 		const ea = excalidraw.ea as ExcalidrawAutomate;
-		const settings = ea.getExportSettings(true, true);
+		const settings = ea.getExportSettings(false, true);
 		const embeddedFilesLoader = ea.getEmbeddedFilesLoader(true);
 		const svg = await ea.createSVG(file.path, true, settings, embeddedFilesLoader);
 		return svg.outerHTML as string;


### PR DESCRIPTION
It seems, based on my testing and my interpretation of the code, that enveloppe always exports excalidraw svgs with a background and white theme as shown by the `ea.getExportSettings(true, true);` (see https://zsviczian.github.io/obsidian-excalidraw-plugin/API/attributes_functions_overview.html). I think for most situations, it would make more sense to export with a transparent background, this is why I switched it to `false, true`. This resolves my discussion #365 

Compare the difference:
![Screenshot 2024-10-05 at 13-35-50 Unit 2](https://github.com/user-attachments/assets/123101d8-fbd9-4e98-97f9-c87b6a995846)
![image](https://github.com/user-attachments/assets/e702b385-cdd0-4a9c-b6a5-e70e06d8b5b8)

Thanks!