### PR TITLE
add Dockerfile, update links in README.md

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# Build and export plugin artifacts.
+# Usage: `docker build --output ./dist .`
+
+FROM node:20-slim AS base
+RUN apt-get update && \
+    apt-get install -y git && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+RUN npm install -g pnpm && pnpm install
+COPY . .
+
+FROM base AS builder
+WORKDIR /usr/src/app
+RUN pnpm run build
+
+FROM scratch AS export
+COPY --from=builder /usr/src/app/dist /

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The plugin adds 8 commands in the palette, one of which is also available in the
 - `Test the connection to the configured repository`
 - `Check the rate limit of the GitHub API`
 
-Each of the commands are explained [here](https://enveloppe.github.io/Commands).
+Each of the commands are explained [here](https://enveloppe.ovh/Commands).
 
 ## 🤖 How it works
 
@@ -74,13 +74,13 @@ Each of the commands are explained [here](https://enveloppe.github.io/Commands).
 
 You can :
 
-- [Maintaining the project and adding new function](https://enveloppe.github.io//Developing#general)
-- [Translate to your language or improve current wording](https://enveloppe.github.io//Developing#translation)
+- [Maintaining the project and adding new function](https://enveloppe.ovh/Getting%20Started/Developing/#plugin-development)
+- [Help with the translation](https://enveloppe.ovh/Getting%20Started/Developing/#translation-or-paraphrasing)
 
 ## 🪧 Looking for something?
 
-→ [Settings explanation](https://enveloppe.github.io//Plugin/Settings/)
-← [Commands references](https://enveloppe.github.io//Commands)
+→ [Settings explanation](https://enveloppe.ovh/Settings/Plugin_config/)
+← [Commands references](https://enveloppe.ovh/Getting%20Started/Commands/)
 → [GitHub Discussion](https://github.com/orgs/Enveloppe/discussions)
 
 ---


### PR DESCRIPTION
The plugin can now be built using Docker.
The documentation has been moved to a new domain, I've updated the links.