### PR TITLE
feat(settings): add toggle for relative path

### DIFF
--- a/src/conversion/file_path.ts
+++ b/src/conversion/file_path.ts
@@ -151,7 +151,9 @@ export async function createRelativePath(
 		return defaultPath;
 	}
 	if (!properties.plugin.settings.conversion.links.relativePath)
-		return { link: targetPath };
+		return {
+			link: `${properties.plugin.settings.conversion.links.textPrefix}${targetPath}`,
+		};
 
 	const sourceList = sourcePath.split("/");
 	const targetList = targetPath.split("/");

--- a/src/conversion/file_path.ts
+++ b/src/conversion/file_path.ts
@@ -1,7 +1,7 @@
 import {
+	type EnveloppeSettings,
 	FIND_REGEX,
 	FolderSettings,
-	type EnveloppeSettings,
 	type LinkedNotes,
 	type MultiProperties,
 	type Properties,
@@ -10,10 +10,10 @@ import {
 } from "@interfaces";
 import {
 	type FrontMatterCache,
-	normalizePath,
 	type TFile,
 	TFolder,
 	type Vault,
+	normalizePath,
 } from "obsidian";
 import { createRegexFromText } from "src/conversion/find_and_replace_text";
 import type Enveloppe from "src/main";
@@ -150,6 +150,8 @@ export async function createRelativePath(
 		);
 		return defaultPath;
 	}
+	if (!properties.plugin.settings.conversion.links.relativePath)
+		return { link: targetPath };
 
 	const sourceList = sourcePath.split("/");
 	const targetList = targetPath.split("/");

--- a/src/interfaces/constant.ts
+++ b/src/interfaces/constant.ts
@@ -75,6 +75,7 @@ export const DEFAULT_SETTINGS: Partial<EnveloppeSettings> = {
 			wiki: false,
 			slugify: "disable",
 			unlink: false,
+			relativePath: true,
 		},
 	},
 	embed: {

--- a/src/interfaces/constant.ts
+++ b/src/interfaces/constant.ts
@@ -76,6 +76,7 @@ export const DEFAULT_SETTINGS: Partial<EnveloppeSettings> = {
 			slugify: "disable",
 			unlink: false,
 			relativePath: true,
+			textPrefix: "/",
 		},
 	},
 	embed: {

--- a/src/interfaces/settings.ts
+++ b/src/interfaces/settings.ts
@@ -212,6 +212,10 @@ export interface Conversion {
 		 * @default `disable`
 		 */
 		slugify: "disable" | "strict" | "lower" | boolean;
+		/**
+		 * Disable relative path creation
+		 */
+		relativePath: boolean;
 	};
 }
 

--- a/src/interfaces/settings.ts
+++ b/src/interfaces/settings.ts
@@ -216,6 +216,11 @@ export interface Conversion {
 		 * Disable relative path creation
 		 */
 		relativePath: boolean;
+		/**
+		 * Only used when relative path is disabled, allow to set any text before the path, like a slash (default)
+		 * @default `/`
+		 */
+		textPrefix: string;
 	};
 }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -796,6 +796,7 @@ export class EnveloppeSettingsTab extends PluginSettingTab {
 						});
 				}
 			}
+
 			new Setting(this.settingsPage)
 				.setName(i18next.t("settings.conversion.links.relativePath.title"))
 				.setDesc(i18next.t("settings.conversion.links.relativePath.desc"))
@@ -803,8 +804,27 @@ export class EnveloppeSettingsTab extends PluginSettingTab {
 					toggle.setValue(textSettings.links.relativePath).onChange(async (value) => {
 						textSettings.links.relativePath = value;
 						await this.plugin.saveSettings();
+						await this.renderSettingsPage("text-conversion");
 					});
 				});
+
+			if (!textSettings.links.relativePath) {
+				new Setting(this.settingsPage)
+					.setName(i18next.t("settings.conversion.links.textBefore.title"))
+					.setDesc(
+						sanitizeHTMLToDom(
+							`<span>${i18next.t("settings.conversion.links.textBefore.desc", { slash: "<code>/</code>" })}</span>`
+						)
+					)
+					.addText((cb) => {
+						cb.setPlaceholder("/")
+							.setValue(textSettings.links.textPrefix)
+							.onChange(async (value) => {
+								textSettings.links.textPrefix = value;
+								await this.plugin.saveSettings();
+							});
+					});
+			}
 		}
 
 		new Setting(this.settingsPage)

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -732,9 +732,10 @@ export class EnveloppeSettingsTab extends PluginSettingTab {
 	 */
 	renderTextConversion() {
 		const textSettings = this.settings.conversion;
-		this.settingsPage.createEl("p", {
-			text: i18next.t("settings.conversion.desc"),
-		});
+
+		this.settingsPage.appendChild(
+			sanitizeHTMLToDom(`<p>${i18next.t("settings.conversion.desc")}</p>`)
+		);
 
 		this.settingsPage.createEl("h5", {
 			text: i18next.t("settings.conversion.links.title"),
@@ -746,15 +747,13 @@ export class EnveloppeSettingsTab extends PluginSettingTab {
 		const shareAll = this.settings.plugin.shareAll?.enable
 			? ` ${i18next.t("settings.conversion.links.internals.shareAll")}`
 			: "";
-		const internalLinksDesc = document.createDocumentFragment();
-		internalLinksDesc.createEl("p", {
-			text: i18next.t("settings.conversion.links.internals.desc") + shareAll,
-			cls: "no-margin",
-		});
-		internalLinksDesc.createEl("p", {
-			text: i18next.t("settings.conversion.links.internals.dataview"),
-			cls: "no-margin",
-		});
+
+		const internalLinksDesc = sanitizeHTMLToDom(
+			dedent(`
+			<p class="no-margin">${i18next.t("settings.conversion.links.internals.desc")} ${shareAll}</p>
+			<p class="no-margin">${i18next.t("settings.conversion.links.internals.dataview")}</p>
+		`)
+		);
 
 		new Setting(this.settingsPage)
 			.setName(i18next.t("settings.conversion.links.internals.title"))
@@ -770,29 +769,42 @@ export class EnveloppeSettingsTab extends PluginSettingTab {
 				});
 			});
 
-		if (textSettings.links.internal && !this.settings.plugin.shareAll?.enable) {
-			new Setting(this.settingsPage)
-				.setName(i18next.t("settings.conversion.links.nonShared.title"))
-				.setDesc(i18next.t("settings.conversion.links.nonShared.desc"))
-				.addToggle((toggle) => {
-					toggle.setValue(textSettings.links.unshared).onChange(async (value) => {
-						textSettings.links.unshared = value;
-						await this.renderSettingsPage("text-conversion");
-						await this.plugin.saveSettings();
-					});
-				});
-
-			if (!textSettings.links.unshared) {
+		if (textSettings.links.internal) {
+			if (!this.settings.plugin.shareAll?.enable) {
 				new Setting(this.settingsPage)
-					.setName(i18next.t("settings.conversion.links.unlink.title"))
-					.setDesc(sanitizeHTMLToDom(i18next.t("settings.conversion.links.unlink.desc")))
+					.setName(i18next.t("settings.conversion.links.nonShared.title"))
+					.setDesc(i18next.t("settings.conversion.links.nonShared.desc"))
 					.addToggle((toggle) => {
-						toggle.setValue(textSettings.links.unlink).onChange(async (value) => {
-							textSettings.links.unlink = value;
+						toggle.setValue(textSettings.links.unshared).onChange(async (value) => {
+							textSettings.links.unshared = value;
+							await this.renderSettingsPage("text-conversion");
 							await this.plugin.saveSettings();
 						});
 					});
+
+				if (!textSettings.links.unshared) {
+					new Setting(this.settingsPage)
+						.setName(i18next.t("settings.conversion.links.unlink.title"))
+						.setDesc(
+							sanitizeHTMLToDom(i18next.t("settings.conversion.links.unlink.desc"))
+						)
+						.addToggle((toggle) => {
+							toggle.setValue(textSettings.links.unlink).onChange(async (value) => {
+								textSettings.links.unlink = value;
+								await this.plugin.saveSettings();
+							});
+						});
+				}
 			}
+			new Setting(this.settingsPage)
+				.setName(i18next.t("settings.conversion.links.relativePath.title"))
+				.setDesc(i18next.t("settings.conversion.links.relativePath.desc"))
+				.addToggle((toggle) => {
+					toggle.setValue(textSettings.links.relativePath).onChange(async (value) => {
+						textSettings.links.relativePath = value;
+						await this.plugin.saveSettings();
+					});
+				});
 		}
 
 		new Setting(this.settingsPage)

--- a/src/utils/status_bar.ts
+++ b/src/utils/status_bar.ts
@@ -96,7 +96,7 @@ export class ShareStatusBar {
 
 	finish(displayDurationMillisec: number) {
 		if (
-			// biome-ignore lint/correctness/noUndeclaredVariables: <explanation>
+			// biome-ignore lint/correctness/noUndeclaredVariables: activeDocument is expected to be available in the runtime environment
 			activeDocument.querySelector(
 				".status-bar-item.plugin-obsidian-mkdocs-publisher.success"
 			)

--- a/src/utils/status_bar.ts
+++ b/src/utils/status_bar.ts
@@ -96,6 +96,7 @@ export class ShareStatusBar {
 
 	finish(displayDurationMillisec: number) {
 		if (
+			// biome-ignore lint/correctness/noUndeclaredVariables: <explanation>
 			activeDocument.querySelector(
 				".status-bar-item.plugin-obsidian-mkdocs-publisher.success"
 			)


### PR DESCRIPTION
- Allow to enable or disabling the relative path creation when a path is created between two files.
- To allow absolute (or not) path, add a settings for prefixing text . By default, use `/` for absolute path. Can be disabled when empty. This settings only appear if **relative path is disabled**.

Output: 
Before:
```
[[../_pages/my-digital-workbench|_pages/my-digital-workbench]]
[[./_posts/2022-10-15-jekyll-with-obsidian|guide/_posts/2022-10-15-jekyll-with-obsidian]]
```
After : 
```
[[/hidden/_pages/my-digital-workbench|_pages/my-digital-workbench]]

[[/hidden/guide/_posts/2022-10-15-jekyll-with-obsidian|guide/_posts/2022-10-15-jekyll-with-obsidian]]
```
Relative to #384 
