### PR TITLE
Add support for "wiki display text" setting

### DIFF
--- a/src/GitHub/files.ts
+++ b/src/GitHub/files.ts
@@ -189,7 +189,10 @@ export class FilesManagement extends Publisher {
 								: imageLink.basename;
 						let frontmatterDestinationFilePath;
 
-						if (this.settings.upload.frontmatterTitle.enable) {
+						if (
+							this.settings.upload.frontmatterTitle.enable &&
+							this.settings.conversion.links.wikiDisplayText
+						) {
 							const frontmatter = this.metadataCache.getCache(
 								imageLink.path
 							)?.frontmatter;
@@ -254,7 +257,10 @@ export class FilesManagement extends Publisher {
 								: linkedFile.basename;
 						let frontmatterDestinationFilePath;
 
-						if (this.settings.upload.frontmatterTitle.enable) {
+						if (
+							this.settings.upload.frontmatterTitle.enable &&
+							!this.settings.conversion.links.wikiDisplayText
+						) {
 							const frontmatter = this.metadataCache.getCache(
 								linkedFile.path
 							)?.frontmatter;

--- a/src/interfaces/constant.ts
+++ b/src/interfaces/constant.ts
@@ -73,6 +73,7 @@ export const DEFAULT_SETTINGS: Partial<EnveloppeSettings> = {
 			internal: false,
 			unshared: false,
 			wiki: false,
+			wikiDisplayText: false,
 			slugify: "disable",
 			unlink: false,
 			relativePath: true,

--- a/src/interfaces/settings.ts
+++ b/src/interfaces/settings.ts
@@ -205,6 +205,9 @@ export interface Conversion {
 		/**
 		 * Convert wikilinks to markdown links */
 		wiki: boolean;
+		/**
+		 * Maintain display text when converting wikilinks */
+		wikiDisplayText: boolean;
 		/** Slugify links if needed
 		 * - `disable` : do not slugify the link
 		 * - `strict` : slugify the link in lower case and remove all special characters (including chinese or russian one)

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -837,6 +837,18 @@ export class EnveloppeSettingsTab extends PluginSettingTab {
 					await this.renderSettingsPage("text-conversion");
 				});
 			});
+		if (textSettings.links.wiki) {
+			new Setting(this.settingsPage)
+				.setName(i18next.t("settings.conversion.links.wikiDisplayText.title"))
+				.setDesc(i18next.t("settings.conversion.links.wikiDisplayText.desc"))
+				.addToggle((toggle) => {
+					toggle.setValue(textSettings.links.wikiDisplayText).onChange(async (value) => {
+						textSettings.links.wikiDisplayText = value;
+						await this.plugin.saveSettings();
+						await this.renderSettingsPage("text-conversion");
+					});
+				});
+		}
 		const slugifySetting =
 			typeof textSettings.links.slugify == "boolean"
 				? textSettings.links.slugify


### PR DESCRIPTION
This maintains the display text on the filename when converting wikilinks. This is helpful for users who use the filename to convert the exported filename but want to maintain the in-vault filename in the text.

---

To be honest, I'm not sure this is broadly useful, but I do have a couple features I would like to add to support the way I want my vault to export. If you're open to it, I'm happy to maintain the new feature and make sure this doesn't cause any bugs for anyone else. I'm also happy to explain why/how I'm using this, if that's helpful as well.

This better supports what I was aiming to do in #394.

I can also update the locales if this is something you'd accept.

Thanks for the great plugin!